### PR TITLE
Bug Fixing: Mocha doesn't run all test files

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "typescript-node-api",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "",
   "main": "index.js",
   "scripts": {
     "start": "node dist/index.js",
-    "test": "mocha --reporter spec --compilers ts:ts-node/register test/**/*.test.ts"
+    "test": "mocha --reporter spec --compilers ts:ts-node/register 'test/**/*.test.ts'"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
Put single quotes around the pattern you pass to Mocha to prevent it being interpreted by your shell: 'src/**/*.test.js'.
What happens is that, without the quotes, your shell tries to expand that pattern and is successful. The result of expansion is src/some-other-module/some-other-module.test.js and this is what is passed to Mocha.
Before you created that file, the shell still tried to expand the pattern but was not successful and left the pattern as-is. So Mocha got src/**/*.test.js, which Mocha itself interpreted as a glob.
In case you wonder, in Bash, unless the globstar option is turned on, ** is equivalent to *.