### PR TITLE
fix outdated ts-node resulting in failing test command

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "gulp": "^3.9.1",
     "gulp-typescript": "^3.1.1",
     "mocha": "^3.1.2",
-    "ts-node": "^1.6.1",
+    "ts-node": "^3.3.0",
     "typescript": "^2.0.6"
   },
   "dependencies": {


### PR DESCRIPTION
Spotted by [this SO post](https://stackoverflow.com/questions/47356367/module-not-found-when-doing-unit-test-with-typescrit-mocha/47356599#47356599).